### PR TITLE
Blogチュートリアルのタイポの修正

### DIFF
--- a/blog_aop.md
+++ b/blog_aop.md
@@ -12,7 +12,7 @@ Note:
 class App_Aspect_Created implements BEAR_Aspect_Before_Interface
     public function before(array $values, BEAR_Aspect_JoinPoint $joinPoint)
     {
-        $values['created'] = _BEAR_DATETIME_;
+        $values['created'] = _BEAR_DATETIME;
         return $values;
     }
 ```
@@ -21,7 +21,7 @@ class App_Aspect_Created implements BEAR_Aspect_Before_Interface
 class App_Aspect_Updated implements BEAR_Aspect_Before_Interface
     public function before(array $values, BEAR_Aspect_JoinPoint $joinPoint)
     {
-        $values['modified'] = _BEAR_DATETIME_;
+        $values['modified'] = _BEAR_DATETIME;
         return $values;
     }
 ```

--- a/blog_aop.md
+++ b/blog_aop.md
@@ -21,7 +21,7 @@ class App_Aspect_Created implements BEAR_Aspect_Before_Interface
 class App_Aspect_Updated implements BEAR_Aspect_Before_Interface
     public function before(array $values, BEAR_Aspect_JoinPoint $joinPoint)
     {
-        $values['updated'] = _BEAR_DATETIME_;
+        $values['modified'] = _BEAR_DATETIME_;
         return $values;
     }
 ```

--- a/blog_pager.md
+++ b/blog_pager.md
@@ -26,7 +26,7 @@ class App_Ro_Post_Pager extends App_Ro_Post
         $this->_queryConfig['pager'] = 1; // DBページャー利用
         $this->_queryConfig['perPage'] = 10; // １ページ毎のアイテム数
         $id = array('id', 'id', '+');
-        $date = array('created_at', 'date', '-');
+        $date = array('created', 'date', '-');
         $this->_queryConfig['sort'] = array($id, $date); // ソート
         $this->_query = BEAR::factory('BEAR_Query', $this->_queryConfig);
     }


### PR DESCRIPTION
Blogチュートリアル内に2つのタイポがあったので修正致します。

## 1. カラム名
[blogチュートリアル(2) データベースの設定](https://github.com/bearsaturday/manual/blob/wiki/blog_db.md)において、作成日は`created`、更新日は`modified`に定義されています。

```
CREATE TABLE posts (
id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
title VARCHAR(50),
body TEXT,
created DATETIME DEFAULT NULL,
modified DATETIME DEFAULT NULL
);
```

しかし、[カスタマイズ編 リソースのページングと表示順](https://github.com/bearsaturday/manual/blob/wiki/blog_pager.md)では、カラム名に`created`ではなく、`created_at`を指定しています。


また、[カスタマイズ編 投稿日時・更新日時の自動挿入とトランザクション(AOP)](https://github.com/bearsaturday/manual/blob/wiki/blog_aop.md)では、`modified`ではなく、`updated`を指定しています。

## 2. 予約変数
[カスタマイズ編 投稿日時・更新日時の自動挿入とトランザクション(AOP)](https://github.com/bearsaturday/manual/blob/wiki/blog_aop.md)において、現在日時を取得する予約変数にタイポがあったので、修正致します。